### PR TITLE
deps/btfdump: use git instead version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,7 @@ dependencies = [
 [[package]]
 name = "btfdump"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b823c21507c564ba9edc7a98e2a30cb5c7ec31047ff2e23d2b806d7877c3e4c"
+source = "git+https://github.com/anakryiko/btfdump?rev=d9587c38#d9587c38d18f2ca82f29ddd77ae5f9f3163319b1"
 dependencies = [
  "bitflags",
  "clap 2.34.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Convert btf info to wit info"
 
 [dependencies]
 anyhow = "1.0.68"
-btfdump = "0.0.1"
+btfdump = { git = "https://github.com/anakryiko/btfdump", rev = "d9587c38" }
 clap = { version = "4.1.4", features = ["derive"] }
 memmap = "0.7.0"
 object = "^0.11.0"


### PR DESCRIPTION
Fix #9 